### PR TITLE
removed git stuff from options.lua

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -18,20 +18,7 @@ vim.opt.termguicolors = true
 vim.opt.swapfile = false
 
 -- LSP
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> merge-with-remote
-vim.lsp.set_log_level(0)
 vim.lsp.set_log_level(2)  -- Info
-<<<<<<< HEAD
->>>>>>> 438b445 (initial commit. stable config)
-=======
-vim.lsp.set_log_level(2)  -- Info
->>>>>>> 438b445 (initial commit. stable config)
-=======
->>>>>>> merge-with-remote
 
 -- Diagnostic
 vim.diagnostic.config({update_in_insert = true})


### PR DESCRIPTION
I accidentally deleted my local git history, but not the actual config files, which I moved. I was trying to redo the config from scratch, to get a better sense of how it works. I wound up restoring my old files, because I was having a hard time figuring out which directories lazy.nvim expected and searched for required modules. I did eventually realize that by putting the logic that initiates lazy.nvim and loads all my plugins in `init.lua` instead of in a separate `plugins.lua` which is required by `init.lua` I shaved approximately half a second off my neovim start up time.